### PR TITLE
Fix run variant expression global os

### DIFF
--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -124,7 +124,7 @@ class TestmonDeselect(object):
         monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
         p = testdir.tmpdir.join('.coveragerc')
         p.write("[")
-        a = testdir.makepyfile(test_a="""
+        testdir.makepyfile(test_a="""
             def test_add():
                 pass
         """)
@@ -174,7 +174,7 @@ class TestmonDeselect(object):
 
     def test_easy(self, testdir, monkeypatch):
         monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
-        a = testdir.makepyfile(test_a="""
+        testdir.makepyfile(test_a="""
             def test_add():
                 assert add(1, 2) == 3
 
@@ -224,7 +224,7 @@ class TestmonDeselect(object):
                 def test_twob(self):
                     print("2")
         """)
-        module2 = Module(cs2.source_code)
+        Module(cs2.source_code)
 
         test_a = testdir.makepyfile(test_a=cs1.source_code)
         result = testdir.runpytest("--testmon", "test_a.py::TestA::test_one",)
@@ -259,7 +259,7 @@ class TestmonDeselect(object):
         ])
 
     def test_nonfunc_class_2(self, testdir):
-        config = testdir.parseconfigure()
+        testdir.parseconfigure()
         cs2 = CodeSample("""\
             class TestA(object):
                 def test_one(self):
@@ -287,7 +287,7 @@ class TestmonDeselect(object):
                 return a - b
         """)
 
-        b = testdir.makepyfile(b="""
+        testdir.makepyfile(b="""
             def divide(a, b):
                 return a // b
 
@@ -295,7 +295,7 @@ class TestmonDeselect(object):
                 return a * b
         """)
 
-        test_a = testdir.makepyfile(test_a="""
+        testdir.makepyfile(test_a="""
             from a import add, subtract
             import time
 
@@ -306,7 +306,7 @@ class TestmonDeselect(object):
                 assert subtract(1, 2) == -1
                     """)
 
-        test_a = testdir.makepyfile(test_b="""
+        testdir.makepyfile(test_b="""
             import unittest
 
             from b import multiply, divide
@@ -319,7 +319,7 @@ class TestmonDeselect(object):
                     self.assertEqual(divide(1, 2), 0)
         """)
 
-        test_ab = testdir.makepyfile(test_ab="""
+        testdir.makepyfile(test_ab="""
             from a import add
             from b import multiply
             def test_add_and_multiply():

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -26,18 +26,14 @@ def test_run_variant_empty(testdir):
     assert eval_variant(config.getini('run_variant_expression')) == ''
 
 
-def test_run_variant_env(testdir):
-    test_v_before = os.environ.get('TEST_V')
-    os.environ['TEST_V'] = 'JUST_A_TEST'
+def test_run_variant_env(testdir, monkeypatch):
+    monkeypatch.setenv('TEST_V', 'JUST_A_TEST')
     testdir.makeini("""
                     [pytest]
                     run_variant_expression=os.environ.get('TEST_V')
                     """)
     config = testdir.parseconfigure()
     assert eval_variant(config.getini('run_variant_expression')) == 'JUST_A_TEST'
-    del os.environ['TEST_V']
-    if test_v_before is not None:
-        os.environ['TEST_V']
 
 def test_run_variant_nonsense(testdir):
     testdir.makeini("""

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -47,6 +47,16 @@ def test_run_variant_nonsense(testdir):
     config = testdir.parseconfigure()
     assert 'NameError' in eval_variant(config.getini('run_variant_expression'))
 
+def test_run_variant_complex(testdir, monkeypatch):
+    "Test that ``os`` is available in list comprehensions."
+    monkeypatch.setenv('TEST_V', 'JUST_A_TEST')
+    testdir.makeini("""
+                    [pytest]
+                    run_variant_expression="_".join([x + ":" + os.environ[x] for x in os.environ if x == 'TEST_V'])
+                    """)
+    config = testdir.parseconfigure()
+    assert eval_variant(config.getini('run_variant_expression')) == 'TEST_V:JUST_A_TEST'
+
 def track_it(testdir, func):
     testmon = Testmon(project_dirs=[testdir.tmpdir.strpath],
                       testmon_labels=set())

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -109,11 +109,11 @@ def eval_variant(run_variant, **kwargs):
     if not run_variant:
         return ''
 
-    eval_locals = {'os': os, 'sys': sys}
-    eval_locals.update(kwargs)
+    eval_globals = {'os': os, 'sys': sys}
+    eval_globals.update(kwargs)
 
     try:
-        return eval(run_variant, {}, eval_locals)
+        return eval(run_variant, eval_globals)
     except Exception as e:
         return repr(e)
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27, py34
 
 [testenv]
-commands = py.test --tb=native
+commands = py.test --tb=native {posargs:test}
 deps =
     coverage_pth
     pytest


### PR DESCRIPTION
The main fix is the first commit: https://github.com/tarpas/pytest-testmon/commit/2165d6a5a1dab9f40c064c0c118f0d937f4798fe

> Fix `os` not being available in a list comprehension