### PR TITLE
Handle non-str `run_variant_expression`

### DIFF
--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -21,6 +21,17 @@ def test_run_variant_header(testdir):
     ])
 
 
+def test_run_variant_header_nonstr(testdir):
+    testdir.makeini("""
+                    [pytest]
+                    run_variant_expression=int(1)
+                    """)
+    result = testdir.runpytest("-v", "--testmon")
+    result.stdout.fnmatch_lines([
+        "*testmon=True, *, run variant: 1*",
+    ])
+
+
 def test_run_variant_empty(testdir):
     config = testdir.parseconfigure()
     assert eval_variant(config.getini('run_variant_expression')) == ''

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -113,7 +113,7 @@ def eval_variant(run_variant, **kwargs):
     eval_locals.update(kwargs)
 
     try:
-        return eval(run_variant, {}, eval_locals)
+        return str(eval(run_variant, {}, eval_locals))
     except Exception as e:
         return repr(e)
 


### PR DESCRIPTION
I have tried to use a complex expression, wrapped with `hash` to keep it
short, which triggered this issue.

> run_variant_expression = hash(','.join(sorted([':'.join([x, os.environ[x]]) for x in os.environ if x.startswith('DJANGO_')])) + ':python' + str(sys.version_info[:2]))

    File "…/testmon/testmon_core.py", line 166, in _fetch_attribute
      [self.variant + ':' + attribute])
    TypeError: unsupported operand type(s) for +: 'int' and 'str'

This conflicts with #24, but it trivial to resolve.