### PR TITLE
Travis: test pytest 2.7 and current, add Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
+python: 3.5
+
+env:
+  matrix:
+    - TOXENV=py27-pytest27
+    - TOXENV=py27-pytestcurrent
+    - TOXENV=py34-pytest27
+    - TOXENV=py34-pytestcurrent
+    - TOXENV=py35-pytest27
+    - TOXENV=py35-pytestcurrent
 
 install:
   - pip install tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pytest>=2.7,<2.9
--e hg+https://bitbucket.org/ned/coveragepy@coverage-3.7.1#egg=coverage
+coverage>=3.7.1,<4.0

--- a/test/test_process_code.py
+++ b/test/test_process_code.py
@@ -290,7 +290,8 @@ class TestCoverageSubprocess(CoverageTest):
             """)
             os.environ['COVERAGE_PROCESS_START']='.testmoncoveragerc'
             self.run_command('python {}'.format(path1))
-            assert os.path.exists('.testmoncoverage')
+            assert os.path.exists('.testmoncoverage'), (
+                os.getcwd(), os.listdir(os.getcwd()))
 
 
 class TestCoverageAssumptions(CoverageTest):

--- a/test/test_process_code.py
+++ b/test/test_process_code.py
@@ -1,10 +1,8 @@
-import sys
 import os
+from test.coveragepy.coveragetest import CoverageTest
 
 import pytest
 from testmon.process_code import Block, Module, checksum_coverage
-import coverage
-from testmon.testmon_core import Testmon
 
 
 def parse(source_code, file_name='a.py'):
@@ -276,7 +274,6 @@ class TestModule(object):
         assert module1.blocks[1] == module2.blocks[1]
         assert module1.blocks[2] != module2.blocks[2]
 
-from test.coveragepy.coveragetest import CoverageTest
 
 class TestCoverageSubprocess(CoverageTest):
 

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -139,7 +139,7 @@ class TestmonDeselect(object):
             def test_add():
                 pass
         """)
-        testdir.inprocess_run(["--testmon", ])
+        testdir.inline_run(["--testmon", ])
 
     def test_not_running_after_failure(self, testdir, monkeypatch):
         monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
@@ -151,7 +151,7 @@ class TestmonDeselect(object):
         reprec = testdir.inline_run( "--testmon", "-v")
         res = reprec.countoutcomes()
         assert tuple(res) == (1, 0, 0), res
-        del sys.modules['test_a']
+        sys.modules.pop('test_a', None)
 
         tf = testdir.makepyfile(test_a="""
             def test_add():
@@ -161,7 +161,7 @@ class TestmonDeselect(object):
         reprec = testdir.inline_run( "--testmon", "-v")
         res = reprec.countoutcomes()
         assert tuple(res) == (0, 0, 1), res
-        del sys.modules['test_a']
+        sys.modules.pop('test_a', None)
 
         tf = testdir.makepyfile(test_a="""
             def test_add():
@@ -171,7 +171,7 @@ class TestmonDeselect(object):
         reprec = testdir.inline_run( "--testmon", "-v")
         res = reprec.countoutcomes()
         assert tuple(res) == (0, 0, 1), res
-        del sys.modules['test_a']
+        sys.modules.pop('test_a', None)
 
         tf = testdir.makepyfile(test_a="""
             def test_add():
@@ -181,7 +181,7 @@ class TestmonDeselect(object):
         reprec = testdir.inline_run( "--testmon", "-v")
         res = reprec.countoutcomes()
         assert tuple(res) == (1, 0, 0), res
-
+        sys.modules.pop('test_a', None)
 
     def test_easy(self, testdir, monkeypatch):
         monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34
+envlist = py{27,34,35}-pytest{27,current}
 
 [testenv]
 commands = py.test --tb=native {posargs:test}
 deps =
     coverage_pth
-    pytest
+    pytest27: pytest>=2.7,<2.8
+    pytestcurrent: pytest>=2.8


### PR DESCRIPTION
I've noticed that tests are failing with pytest 2.8.x, so I've gone ahead and improved the Travis / tox matrix setup to test both pytest 2.7 and 2.8 for now.

This also adds Python 3.5 to the matrix.