### PR TITLE
Don't install README.rst to datadir

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     url='https://github.com/tarpas/pytest-testmon/',
     author_email='tibor.arpas@infinit.sk',
     author='Tibor Arpas, Jozef Knaperek, Martin Riesz',
-    data_files=([('', ['README.rst']), ]),
     entry_points={
         'pytest11': [
             'testmon = testmon.pytest_testmon',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(
     name='pytest-testmon',
     description='take TDD to a new level with py.test and testmon',
+    long_description=''.join(open('README.rst').readlines()),
     version='0.8.1',
     license='MIT',
     platforms=['linux', 'osx', 'win32'],


### PR DESCRIPTION
This will result in /usr/README.rst on Linux and I'm quite sure that's not a good idea.