### PR TITLE
subprocess and cmd wrapper for variants

### DIFF
--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -122,10 +122,14 @@ def eval_variant(run_variant, **kwargs):
     def md5(s):
         return hashlib.md5(s.encode()).hexdigest()
 
+    def cmd(s):
+        return subprocess.check_output(s).decode('utf-8').rstrip()
+
     eval_globals = {'os': os,
                     'subprocess': subprocess,
                     'sys': sys,
                     'hashlib': hashlib,
+                    'cmd': cmd,
                     'md5': md5}
     eval_globals.update(kwargs)
 

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import sys
 import textwrap
 import random
+import subprocess
 
 import coverage
 from testmon.process_code import checksum_coverage
@@ -121,7 +122,11 @@ def eval_variant(run_variant, **kwargs):
     def md5(s):
         return hashlib.md5(s.encode()).hexdigest()
 
-    eval_globals = {'os': os, 'sys': sys, 'hashlib': hashlib, 'md5': md5}
+    eval_globals = {'os': os,
+                    'subprocess': subprocess,
+                    'sys': sys,
+                    'hashlib': hashlib,
+                    'md5': md5}
     eval_globals.update(kwargs)
 
     try:


### PR DESCRIPTION
`subprocess` is useful in general, and `cmd` can be used for getting output easily.

I'm up for discussion about the `cmd` wrapper (name and what it does).
