### PR TITLE
WIP: save data with --xfail / -x

### DIFF
--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -184,7 +184,7 @@ class TestmonDeselect(object):
             self.testmon_data.write_data()
         self.testmon.close()
 
-    def pytest_terminal_summary(self, terminalreporter, exitstatus):
+    def pytest_terminal_summary(self, terminalreporter, exitstatus=None):
         if (not self.testmon_save and
                 terminalreporter.config.getvalue('verbose')):
             terminalreporter.line('testmon: not saving data')

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -99,8 +99,11 @@ class Testmon(object):
         self.cov.erase()
         self.cov.start()
 
-    def stop_and_save(self, testmon_data, rootdir, nodeid):
+    def stop(self):
         self.cov.stop()
+
+    def stop_and_save(self, testmon_data, rootdir, nodeid):
+        self.stop()
         if hasattr(self, 'sub_cov_file'):
             self.cov.combine()
 


### PR DESCRIPTION
When using `-x` to abort the test run on the first failure,
pytest-testmon would previously not store the collected data: the
`pytest_keyboard_interrupt` hook that is used for this gets also called
for pytest's internal `Interrupted` exception, which is a subclass of
`KeyboardInterrupt` (https://github.com/pytest-dev/pytest/issues/1865).

This patch changes it to use the result in the `pytest_runtest_protocol`
method to check for `KeyboardInterrupt` there explicitly.

This makes the `pytest_keyboard_interrupt` obsolete, but I've left it
with some asserts for now.