### PR TITLE
Close file after reading with checksum.

### DIFF
--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -140,9 +140,9 @@ def get_variant_inifile(inifile):
 
 
 def read_file_with_checksum(absfilename):
-    afile = open(absfilename)
     hasher = hashlib.sha1()
-    source = afile.read()
+    with open(absfilename) as afile:
+        source = afile.read()
     hasher.update(encode(source))
     return source, hasher.hexdigest()
 


### PR DESCRIPTION
I was getting warnings like the following when using the plugin (using python3.5). This PR fixes this by closing the file after reading.

```
...lib/python3.5/site-packages/testmon/testmon_core.py:183: ResourceWarning: unclosed file <_io.TextIOWrapper name='...' mode='r' encoding='UTF-8'>
  code, checksum = read_file_with_checksum(os.path.join(self.rootdir, filename))
```