### PR TITLE
Prevent running with mismatched data version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: https://secure.travis-ci.org/tarpas/pytest-testmon.png?branch=master
    :alt: Build Status
-   :target: https://secure.travis-ci.org/tarpas/pytest-testmon.png
+   :target: https://travis-ci.org/tarpas/pytest-testmon
 
 
 This is a py.test plug-in which automatically selects and re-executes only tests affected by recent changes. How is this possible in dynamic language like Python and how reliable is it? Read here: `Determining affected tests <https://github.com/tarpas/pytest-testmon/wiki/Determining-affected-tests>`_

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -439,6 +439,25 @@ class TestmonDeselect(object):
             "*1 skipped*",
         ])
 
+    def test_changed_data_version(self, testdir, monkeypatch):
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", 1)
+        testdir.makepyfile(test_pass="""
+            def test_pass():
+                pass
+        """)
+        result = testdir.runpytest("--testmon")
+        assert result.ret == 0
+
+        # Now change the data version and check py.test then refuses to run
+        from testmon.testmon_core import TestmonData
+        monkeypatch.setattr(TestmonData, 'DATA_VERSION', TestmonData.DATA_VERSION + 1)
+
+        result = testdir.runpytest("--testmon")
+        assert result.ret != 0
+        result.stderr.fnmatch_lines([
+            "*The stored data file *.testmondata is not compatible with this version of testmon.*",
+        ])
+
 
 def get_modules(hashes):
     return hashes


### PR DESCRIPTION
I came across this package via http://stackoverflow.com/questions/35097577/pytest-run-only-the-changed-file, which led me to https://pypi.python.org/pypi/pytest-testmon, where there's a warning

> New versions usually have new dataformat, don’t forget to rm .testmondata after each upgrade.

It seemed like it wouldn't be too hard and then I saw #55 also says it's a problem, so I had a go at fixing it.

Remaining problems:
* Developers have to remember to bump `TestmonData.DATA_VERSION` if they made a breaking change to the data, otherwise this approach doesn't work
* Bombing out of the plugin setup by raising `Exception` seems ugly, but I'm not sure of a better way to achieve this...