### PR TITLE
init_testmon_data in configure, close it in unconfigure

### DIFF
--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -103,9 +103,7 @@ def init_testmon_data(config, read_source=True):
 
 
 def pytest_cmdline_main(config):
-    if config.option.testmon:
-        init_testmon_data(config)
-    elif config.option.by_test_count:
+    if config.option.by_test_count:
         init_testmon_data(config, read_source=False)
         from _pytest.main import wrap_session
 
@@ -118,8 +116,14 @@ def is_active(config):
 
 def pytest_configure(config):
     if is_active(config):
+        init_testmon_data(config)
         config.pluginmanager.register(TestmonDeselect(config, config.testmon_data),
                                       "TestmonDeselect")
+
+
+def pytest_unconfigure(config):
+    if hasattr(config, 'testmon_data'):
+        config.testmon_data.close_connection()
 
 
 def by_test_count(config, session):

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -220,6 +220,10 @@ class TestmonData(object):
 
         self._check_data_version()
 
+    def close_connection(self):
+        if self.connection:
+            self.connection.close()
+
     def _check_data_version(self):
         stored_data_version = self._fetch_attribute(self._DATA_VERSION_KEY)
 


### PR DESCRIPTION
Fixes https://github.com/tarpas/pytest-testmon/issues/68.

For reference: this is how pytest-watch collects the tests silently: https://github.com/joeyespo/pytest-watch/blob/91bc8a1193dc99fcd51852561f8211010fe62c58/pytest_watch/config.py#L47-L52.