### PR TITLE
Reexecute all last failed tests regardless of source change status (tlf)

### DIFF
--- a/t.py
+++ b/t.py
@@ -1,7 +1,8 @@
 import pytest
 
 if __name__ == '__main__':
-    #test/test_testmon.py::TestmonDeselect::test_nonfunc_class
+    # test/test_testmon.py::TestmonDeselect::test_nonfunc_class
+    # test/test_testmon.py::TestmonDeselect::test_tlf
     pytest.main("--tb=native -v" )
     #pytest.main("-v -n 2 --tx=popen//python=python3")
     #pytest.main("--help -v")

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -192,6 +192,25 @@ class TestmonDeselect(object):
         assert tuple(res) == (1, 0, 0), res
         sys.modules.pop('test_a', None)
 
+    def test_tlf(self, testdir):
+        tf = testdir.makepyfile(test_a="""
+            def test_add():
+                1/0
+        """, )
+        testdir.inline_run("--testmon", "-v")
+        sys.modules.pop('test_a', None)
+
+        result = testdir.runpytest("--testmon", "-v")
+        result.stdout.fnmatch_lines([
+            "*1 failed, 1 deselected*",
+        ])
+        tf.setmtime(1424880936)
+        result = testdir.runpytest("--testmon", "-v", "--tlf")
+        result.stdout.fnmatch_lines([
+            "*1 failed in*",
+        ])
+
+
     def test_easy(self, testdir, monkeypatch):
         testdir.makepyfile(test_a="""
             def test_add():

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -193,18 +193,17 @@ class TestmonDeselect(object):
         sys.modules.pop('test_a', None)
 
     def test_tlf(self, testdir):
-        tf = testdir.makepyfile(test_a="""
+        testdir.makepyfile(test_a="""
             def test_add():
                 1/0
         """, )
         testdir.inline_run("--testmon", "-v")
-        sys.modules.pop('test_a', None)
 
         result = testdir.runpytest("--testmon", "-v")
         result.stdout.fnmatch_lines([
             "*1 failed, 1 deselected*",
         ])
-        tf.setmtime(1424880936)
+
         result = testdir.runpytest("--testmon", "-v", "--tlf")
         result.stdout.fnmatch_lines([
             "*1 failed in*",

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -42,6 +42,13 @@ def pytest_addoption(parser):
     )
 
     group.addoption(
+        '--tlf',
+        action='store_true',
+        dest='tlf',
+        help="Re-execute last failures regardless of source change status",
+    )
+
+    group.addoption(
         '--by-test-count',
         action='store_true',
         dest='by_test_count',
@@ -98,7 +105,7 @@ def init_testmon_data(config, read_source=True):
                                    variant=variant)
         testmon_data.read_data()
         if read_source:
-            testmon_data.read_source()
+            testmon_data.read_source(tlf=config.getoption('tlf'))
         config.testmon_data = testmon_data
 
 


### PR DESCRIPTION
--testmon --tlf forces reexecution of all failures even if the underlying source code didn't change. This serves if you wan't different error output or if you corrupted .testmondata through unaccesible external service or wrong virtualenv.