### PR TITLE
Look at TESTMON_DATAFILE to configure datafile location

### DIFF
--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -220,7 +220,9 @@ class TestmonData(object):
         self.reports = defaultdict(lambda: [])
 
     def init_connection(self):
-        self.datafile = os.path.join(self.rootdir, '.testmondata')
+        self.datafile = os.environ.get(
+            'TESTMON_DATAFILE',
+            os.path.join(self.rootdir, '.testmondata'))
         self.connection = None
 
         new_db = not os.path.exists(self.datafile)


### PR DESCRIPTION
I am looking into adding a "testmon" factor to pytest's tox.ini, but
noticed that this should be kept per tox environment.

Therefore the `tox.ini` could specify:

```ini
setenv =
    testmon: TESTMON_DATAFILE={envdir}/.testmondata
```

There are likely other use cases where this would come in handy.

What do you think?

TODO:

- [ ] doc

[ci skip]