### PR TITLE
[WIP/RFC] Add tox plugin to handle --testmon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ setup(
     entry_points={
         'pytest11': [
             'testmon = testmon.pytest_testmon',
-        ]
+        ],
+        'tox': [
+            'testmon = testmon.tox_testmon',
+        ],
     },
     install_requires=['pytest>=2.8.0,<4', 'coverage>=4'],
     classifiers=[

--- a/testmon/tox_testmon.py
+++ b/testmon/tox_testmon.py
@@ -1,0 +1,57 @@
+"""
+A tox plugin to automatically install and use pytest-testmon with tox.
+
+It installs pytest-testmon once `--testmon` is used in one of the commands
+(starting with "pytest" or "py.test").
+
+It also sets the TESTMON_DATAFILE environment variable (always) to use a
+datafile in the venv's directory.
+
+It uses the tox_runenvreport hook instead of tox_testenv_install_deps (where
+it could just add the dep unconditionally) to only install pytest-testmon on
+demand.  Changing envconfig.deps on demand would re-create the venv.
+"""
+import os
+
+import pluggy
+from tox.config import DepConfig
+
+hookimpl = pluggy.HookimplMarker("tox")
+
+
+def _uses_testmon(envconfig):
+    """Test if an envconfig uses testmon by looking at the command(s).
+
+    The command will include resolved {posargs} already, i.e. arguments passed
+    on the command line.
+    """
+    for command in envconfig.commands:
+        if command[0] == 'pytest' or command[0] == 'py.test':
+            if '--testmon' in command:
+                return True
+    return False
+
+
+def touch_stampfile(venv):
+    open(venv.path.join('.testmon_installed'), 'a').close()
+
+
+def installed_testmon(venv):
+    return os.path.exists(venv.path.join('.testmon_installed'))
+
+
+@hookimpl
+def tox_runenvreport(venv, action):
+    datafile = str(venv.path.join('.testmondata'))
+    action.setactivity('testmon', 'setting TESTMON_DATAFILE=%s' % datafile)
+    venv.envconfig.setenv['TESTMON_DATAFILE'] = datafile
+
+    if (_uses_testmon(venv.envconfig)
+            and 'pytest-testmon' not in (x.name for x in venv.envconfig.deps)):
+        if not installed_testmon(venv):
+            action.setactivity('testmon', 'installing pytest-testmon')
+            # Uses _install for handling configured indexservers.
+            # venv.run_install_command(['pytest-testmon'], action=action)
+            venv._install([DepConfig('pytest-testmon')], action=action)
+
+            touch_stampfile(venv)


### PR DESCRIPTION
- sets TESTMON_DATAFILE to use a data file per tox venv
- installs pytest-testmon into a tox venv when --testmon gets used