### PR TITLE
Do not save data with _pytest.outcomes.Exit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-pytestfeatures
       python: 3.6
-    - env: TOXENV=py36-pytest32-xdist
+    - env: TOXENV=py36-pytest41-xdist
       python: 3.6
 
 install:

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -301,6 +301,30 @@ def test_add():
         # interrupted run shouldn't save .testmondata
         assert 1800000000 == os.path.getmtime(datafilename)
 
+    def test_outcomes_exit(self, testdir):
+        testdir.makepyfile(test_a="""
+             def test_1():
+                 1
+
+             def test_2():
+                 2
+         """)
+        testdir.runpytest("--testmon")
+
+        tf = testdir.makepyfile(test_a="""
+             def test_1():
+                 import pytest
+                 pytest.exit("pytest_exit")
+
+             def test_2():
+                 3
+         """)
+        os.utime(datafilename, (1800000000, 1800000000))
+        tf.setmtime(1800000000)
+        testdir.runpytest("--testmon", )
+        # interrupted run shouldn't save .testmondata
+        assert 1800000000 == os.path.getmtime(datafilename)
+
     def test_nonfunc_class(self, testdir, monkeypatch):
         """"
         """

--- a/test/test_testmon.py
+++ b/test/test_testmon.py
@@ -812,14 +812,14 @@ class TestXdist(object):
 
     def test_xdist_4(self, testdir):
         pytest.importorskip("xdist")
-        testdir.makepyfile(test_a="""\
+        testdir.makepyfile(test_a="""
             import pytest
             @pytest.mark.parametrize("a", [
                                     ("test0", ),
                                     ("test1", ),
                                     ("test2", ),
                                     ("test3", )
-    ])
+            ])
             def test_1(a):
                 print(a)
             """)

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -215,7 +215,8 @@ class TestmonDeselect(object):
         else:
             self.testmon.start()
             result = yield
-            if result.excinfo and issubclass(result.excinfo[0], KeyboardInterrupt):
+            if result.excinfo and issubclass(result.excinfo[0], (
+                    KeyboardInterrupt, SystemExit)):
                 self.testmon.stop()
             else:
                 self.testmon.stop_and_save(self.testmon_data, item.config.rootdir.strpath, item.nodeid,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pytest{31,32,33,master}-py{27,34,35,36},py36-pytest32-xdist,pytestfeatures-py36
+envlist = pytest{31,32,33,master}-py{27,34,35,36},py36-pytest41-xdist,pytestfeatures-py36
 
 [testenv]
 passenv = PYTHONPATH
@@ -11,6 +11,7 @@ deps =
     pytest31: pytest>=3.1,<3.2
     pytest32: pytest>=3.2,<3.3
     pytest33: pytest>=3.3,<3.4
+    pytest41: pytest>=4.1,<4.2
     # master is current stable version with bugfixes.
     pytestmaster: git+https://github.com/pytest-dev/pytest.git@master#egg=pytest
     # features is the next non-bugfix version.


### PR DESCRIPTION
This was changed in pytest (will be in 4.1).

`Exit` is derived from `SystemExit` and not `KeyboardInterrupt` anymore.

Ref https://github.com/pytest-dev/pytest/pull/4292