### PR TITLE
Stop --testmon-readonly from touching .testmondata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='pytest-testmon',
     description='take TDD to a new level with py.test and testmon',
     long_description=''.join(open('README.rst').readlines()),
-    version='0.9.14',
+    version='0.9.15',
     license='MIT',
     platforms=['linux', 'osx', 'win32'],
     packages=['testmon'],

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -238,6 +238,6 @@ class TestmonDeselect(object):
         self.testmon_save = False
 
     def pytest_sessionfinish(self, session):
-        if self.testmon_save and not self.config.getoption('collectonly'):
+        if self.testmon_save and not self.config.getoption('collectonly') and not self.config.getoption('testmon_readonly'):
             self.testmon_data.write_data()
         self.testmon.close()


### PR DESCRIPTION
This fixes issue 121 (which I created)