### PR TITLE
setup.cfg: add flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[flake8]
+ignore = E501,W504


### PR DESCRIPTION
Since you appear to prefer/use long lines this ignores E501, and then picks W504 ("W504 line break after binary operator") over W503, since it is used like this in https://github.com/blueyed/testmon/blob/85dd66a1b1b34e357f2da55c14a50fa4109ed828/testmon/pytest_testmon.py#L203.