### PR TITLE
Corrected crash when there is a syntax error in a code file

### DIFF
--- a/testmon/process_code.py
+++ b/testmon/process_code.py
@@ -47,6 +47,7 @@ class Module(object):
         self.full_lines = list(filter(lambda x: not blank_re.match(x), self.lines))
         self._full_lines_checksums = []
 
+        self.special_blocks = {}
         try:
             self.ast = ast.parse(source_code)
             self.special_blocks = dict(function_lines(self.ast, len(self.lines)))


### PR DESCRIPTION
If the exception is raised `special_blocks` is never set causing https://github.com/tarpas/pytest-testmon/blob/63adfc7ed4e0dac77e2d24d5937a72d0df3dc1d0/testmon/testmon_core.py#L338 to call it with a value of `None` and causing https://github.com/tarpas/pytest-testmon/blob/63adfc7ed4e0dac77e2d24d5937a72d0df3dc1d0/testmon/process_code.py#L168 to raise a `TypeError`

