### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ author = Tibor Arpas, Tomas Matlovic, Daniel Hahler, Martin Racak
 description = selects tests affected by changed files and methods
 long_description = file: README.rst
 url = https://testmon.org
+project_urls =
+    Source=https://github.com/tarpas/pytest-testmon
 platforms =
     linux
     osx


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)