### PR TITLE
Fix/improve linting of the code when using pytest-pylint

### DIFF
--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -129,7 +129,7 @@ def init_testmon_data(config, read_source=True):
         config.rootdir.strpath, environment=environment, libraries=libraries
     )
     if read_source:
-        testmon_data.determine_stable()
+        testmon_data.determine_stable(include_changed_source_files=config.getoption("pylint"))
     config.testmon_data = testmon_data
 
 

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -249,7 +249,7 @@ class TestmonData(object):
             library_misses,
         )
 
-    def determine_stable(self):
+    def determine_stable(self, include_changed_source_files=False):
 
         filenames_fingerprints = self.filenames_fingerprints
 
@@ -267,6 +267,8 @@ class TestmonData(object):
         for fingerprint_miss in fingerprint_misses:
             self.unstable_nodeids.add(fingerprint_miss[1])
             self.unstable_files.add(fingerprint_miss[1].split("::", 1)[0])
+            if include_changed_source_files:
+                self.unstable_files.add(fingerprint_miss[0].split("::", 1)[0])
 
         self.stable_nodeids = set(self.all_nodes) - self.unstable_nodeids
         self.stable_files = self.all_files - self.unstable_files


### PR DESCRIPTION
This also includes changed source code files when pytest-pylint is enabled. By default source code files are ignored so the pylint is not able to process those files.