### PR TITLE
Fix crash for files with spaces

### DIFF
--- a/testmon/process_code.py
+++ b/testmon/process_code.py
@@ -219,8 +219,8 @@ def get_files_shas(directory):
 
     modified_files = set()
     for line in result.stdout.splitlines():
-        _, hsh, filename_with_junk = line.split(" ")
-        _, filename = filename_with_junk.split("\t")
+        _, hsh, filename_with_junk = line.split(" ", 2)
+        _, filename = filename_with_junk.split("\t", 1)
         if filename in all_shas:
             modified_files.add(filename)
         else:


### PR DESCRIPTION
Sometimes, `git ls-files --stage -m .` would give me a aline such as

  100644 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 0	foo bar.ext

This makes pytest-testmon crash, because it splits this by " " and then by "\t" to extract the filename.
Limiting the splits to the number that we expect should solve the problem.

For searchability, this is the error I was getting:

```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/_pytest/main.py", line 266, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1039, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/pluggy/_hooks.py", line 277, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/pluggy/_callers.py", line 60, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/pluggy/_callers.py", line 39, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/testmon/pytest_testmon.py", line 208, in pytest_configure
INTERNALERROR>     init_testmon_data(config)
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/testmon/pytest_testmon.py", line 153, in init_testmon_data
INTERNALERROR>     testmon_data.determine_stable(bool(rpc_proxy))
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/testmon/testmon_core.py", line 228, in determine_stable
INTERNALERROR>     module = self.source_tree.get_file(filename)
INTERNALERROR>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/testmon/testmon_core.py", line 59, in get_file
INTERNALERROR>     code, checksum = get_source_sha(
INTERNALERROR>                      ^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/testmon/process_code.py", line 235, in get_source_sha
INTERNALERROR>     sha = get_files_shas(directory)[filename]
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/path/to/python-3.11.1/lib/python3.11/site-packages/testmon/process_code.py", line 222, in get_files_shas
INTERNALERROR>     _, hsh, filename_with_junk = line.split(" ")
INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> ValueError: too many values to unpack (expected 3)

```