### PR TITLE
fix: Increase sqlite connect timeout to 60s

### DIFF
--- a/testmon/db.py
+++ b/testmon/db.py
@@ -21,7 +21,7 @@ class TestmonDbException(Exception):
 
 def connect(datafile, readonly=False):
     connection = sqlite3.connect(
-        f"file:{datafile}{'?mode=ro' if readonly else ''}", uri=True
+        f"file:{datafile}{'?mode=ro' if readonly else ''}", uri=True, timeout=5000
     )
 
     connection.execute("PRAGMA journal_mode = WAL")

--- a/testmon/db.py
+++ b/testmon/db.py
@@ -21,7 +21,7 @@ class TestmonDbException(Exception):
 
 def connect(datafile, readonly=False):
     connection = sqlite3.connect(
-        f"file:{datafile}{'?mode=ro' if readonly else ''}", uri=True, timeout=5000
+        f"file:{datafile}{'?mode=ro' if readonly else ''}", uri=True, timeout=60
     )
 
     connection.execute("PRAGMA journal_mode = WAL")


### PR DESCRIPTION
[Related issue](https://github.com/tarpas/pytest-testmon/issues/203)

[sqlite3.connect](https://docs.python.org/3/library/sqlite3.html#sqlite3.connect)

Default timeout 5s.

Change sqlite connect timeout to 60s to avoid database locking issues. This works wit h `-n16` xdist workers.