### PR TITLE
feat: add configuration option for connect timeout

### DIFF
--- a/testmon/configure.py
+++ b/testmon/configure.py
@@ -1,5 +1,6 @@
 import sys
 import re
+from typing import Optional
 
 try:
     from coverage.tracer import CTracer as Tracer
@@ -103,6 +104,7 @@ class TmConf:
     collect: bool
     select: bool
     tmnet: bool = False
+    connect_timeout: Optional[int] = None
 
     def __eq__(self, other):
         return (
@@ -110,6 +112,7 @@ class TmConf:
             and self.collect == other.collect
             and self.select == other.select
             and self.tmnet == other.tmnet
+            and self.connect_timeout == other.connect_timeout
         )
 
 
@@ -150,6 +153,7 @@ def _header_collect_select(
         not bool(nocollect_reasons),
         not bool(noselect_reasons),
         bool(options.get("tmnet")),
+        int(options.get("testmon_connect_timeout")),
     )
 
 

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -68,6 +68,17 @@ def pytest_addoption(parser):
     )
 
     group.addoption(
+        "--testmon-connect-timeout",
+        action="store",
+        type=int,
+        default=60,
+        dest="testmon_connect_timeout",
+        help=(
+            "Set the timeout for opening a connection to the sqlite database."
+        ),
+    )
+
+    group.addoption(
         "--testmon-forceselect",
         action="store_true",
         dest="testmon_forceselect",
@@ -133,7 +144,7 @@ def testmon_options(config):
     return result
 
 
-def init_testmon_data(config):
+def init_testmon_data(config, connect_timeout):
     environment = config.getoption("environment_expression") or eval_environment(
         config.getini("environment_expression")
     )
@@ -175,6 +186,7 @@ def init_testmon_data(config):
         database=rpc_proxy,
         environment=environment,
         system_packages=system_packages,
+        connect_timeout=connect_timeout,
     )
     testmon_data.determine_stable(bool(rpc_proxy))
     config.testmon_data = testmon_data
@@ -231,7 +243,7 @@ def pytest_configure(config):
     config.testmon_config = tm_conf
     if tm_conf.select or tm_conf.collect:
         try:
-            init_testmon_data(config)
+            init_testmon_data(config, connect_timeout=tm_conf.connect_timeout)
             register_plugins(config, tm_conf.select, tm_conf.collect, cov_plugin)
         except TestmonException as error:
             pytest.exit(str(error))

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -31,6 +31,7 @@ from testmon.process_code import (
 
 
 TEST_BATCH_SIZE = 250
+DEFAULT_DATABASE_CONNECT_TIMEOUT = 60
 
 CHECKUMS_ARRAY_TYPE = "I"
 DB_FILENAME = ".testmondata"
@@ -141,6 +142,7 @@ class TestmonData:
         environment=None,
         system_packages=None,
         python_version=None,
+        connect_timeout=None,
     ):
         self.rootdir = rootdir
         self.environment = environment if environment else "default"
@@ -150,11 +152,12 @@ class TestmonData:
         system_packages = drop_patch_version(system_packages)
         if not python_version:
             python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        connect_timeout = int(connect_timeout) if connect_timeout else DEFAULT_DATABASE_CONNECT_TIMEOUT
 
         if database:
             self.db = database
         else:
-            self.db = db.DB(os.path.join(self.rootdir, get_data_file_path()))
+            self.db = db.DB(os.path.join(self.rootdir, get_data_file_path()), connect_timeout=connect_timeout)
 
         try:
             result = self.db.initiate_execution(
@@ -175,7 +178,7 @@ class TestmonData:
                 ),
                 exc,
             )
-            self.db = db.DB(os.path.join(self.rootdir, get_data_file_path()))
+            self.db = db.DB(os.path.join(self.rootdir, get_data_file_path()), connect_timeout=connect_timeout)
             result = self.db.initiate_execution(
                 self.environment, system_packages, python_version, {}
             )


### PR DESCRIPTION
[Related issue](https://github.com/tarpas/pytest-testmon/issues/203)

[sqlite3.connect](https://docs.python.org/3/library/sqlite3.html#sqlite3.connect)

Default timeout 60s.

Database locking issues still occur with 60s timeout and >100MB sqlite database when `xdist` is running 16 workers. Add an option to specify timeout `--testmon-connect-timeout`