### PR TITLE
get_logger: only configure the logger passed instead of the root logger

### DIFF
--- a/testmon/common.py
+++ b/testmon/common.py
@@ -26,8 +26,16 @@ def dummy():
 
 
 def get_logger(name):
-    logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
-    return logging.getLogger(name)
+    # Create a formatter and set it on a new handler
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    # Configure the logger
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    return logger
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
At the moment as soon as `get_logger` is called in `testmon` logging is configured globally (the root logger is) which impacts every user of pytest that installs pytest-testmon even if pytest-testmon is not enabled.

As a result, test suites print out many log lines that often would not have been printed out, with an unexpected formatting.

This PR fixes it by only configuring the logger passed to `get_logger` instead of the root logger.