### PR TITLE
Use collection_path instead of path (deprecated) in pytest_ignore_collect

### DIFF
--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -9,6 +9,7 @@ import os
 from collections import defaultdict
 from datetime import date, timedelta
 
+from pathlib import Path
 import pytest
 
 from _pytest.config import ExitCode, Config
@@ -471,8 +472,8 @@ class TestmonSelect:
         ]
         self._interrupted = False
 
-    def pytest_ignore_collect(self, path, config):
-        strpath = cached_relpath(path.strpath, config.rootdir.strpath)
+    def pytest_ignore_collect(self, collection_path: Path, path, config):
+        strpath = cached_relpath(str(collection_path), config.rootdir.strpath)
         if strpath in self.deselected_files and self.config.testmon_config.select:
             return True
         return None

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -472,7 +472,7 @@ class TestmonSelect:
         ]
         self._interrupted = False
 
-    def pytest_ignore_collect(self, collection_path: Path, path, config):
+    def pytest_ignore_collect(self, collection_path: Path, config):
         strpath = cached_relpath(str(collection_path), config.rootdir.strpath)
         if strpath in self.deselected_files and self.config.testmon_config.select:
             return True


### PR DESCRIPTION
pytest has deprecated the `path` argument in `pytest_ignore_collect()`, and now recommends using the `collection_path` argument instead. This leads to the deprecation warnings mentioned in issue #237.

I don't know how to test that my change works, and can't see any guidance on contributions. But hopefully this PR addresses the problem and gets rid of those pesky warnings in the console.

Closes #237 