### PR TITLE
support python 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,11 +29,12 @@ classifiers =
         Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
         Programming Language :: Python :: 3.11
+        Programming Language :: Python :: 3.12
         Programming Language :: Python :: 3 :: Only
         Framework :: Pytest
 
 [options]
-python_requires = >=3.7, <3.12
+python_requires = >=3.7, <3.13
 install_requires =
     pytest>=5,<8
     coverage>=6,<8


### PR DESCRIPTION
v1 says that python 3.12 isn't support but it seems to work just fine

This issue https://github.com/tarpas/pytest-testmon/issues/234 is blocking me from upgrading to main