### PR TITLE
Support Pytest v9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Framework :: Pytest",
 ]
 dependencies = [
-    "pytest>=5,<9",
+    "pytest>=5,<10",
     "coverage>=6,<8",
 ]
 


### PR DESCRIPTION
Not sure how to test this properly, but the [Pytest changelog](https://docs.pytest.org/en/stable/changelog.html#removals-and-backward-incompatible-breaking-changes) doesn't seem to have any breaking changes that affect `pytest-testmon`