### PR TITLE
Reduce .testmondata size by 40%

### DIFF
--- a/testmon/db.py
+++ b/testmon/db.py
@@ -10,7 +10,7 @@ from testmon.process_code import blob_to_checksums, checksums_to_blob
 from testmon.common import TestExecutions
 
 
-DATA_VERSION = 14
+DATA_VERSION = 15
 
 ChangedFileData = namedtuple(
     "ChangedFileData", "filename name method_checksums id failed"
@@ -394,10 +394,10 @@ class DB:  # pylint: disable=too-many-public-methods
             CREATE TABLE test_execution_file_fp (
                 test_execution_id INTEGER,
                 fingerprint_id INTEGER,
+                PRIMARY KEY (test_execution_id, fingerprint_id),
                 FOREIGN KEY(test_execution_id) REFERENCES test_execution(id) ON DELETE CASCADE,
                 FOREIGN KEY(fingerprint_id) REFERENCES file_fp(id)
-            );
-            CREATE INDEX test_execution_file_fp_both ON test_execution_file_fp (test_execution_id, fingerprint_id);
+            ) WITHOUT ROWID;
             -- the following table stores the same data coarsely, but is used for faster queries
             CREATE TABLE suite_execution_file_fsha (
                 suite_execution_id INTEGER,


### PR DESCRIPTION
`.testmondata` is about 40% bigger than it needs to be. On my suite its 18.1 MiB, and 11.8 MiB of that is one table whose rows are held twice: 5.7 MiB in `test_execution_file_fp` and 6.1 MiB in an index over the same rows.

The table is two integer columns and `test_execution_file_fp_both` indexes both of them:

```sql
CREATE TABLE test_execution_file_fp (
    test_execution_id INTEGER,
    fingerprint_id INTEGER,
    FOREIGN KEY(test_execution_id) REFERENCES test_execution(id) ON DELETE CASCADE,
    FOREIGN KEY(fingerprint_id) REFERENCES file_fp(id)
);
CREATE INDEX test_execution_file_fp_both ON test_execution_file_fp (test_execution_id, fingerprint_id);
```

Indexing both columns of a two column table means the index is a full copy of the 456,694 pairs. All the readers filter on both columns and get served from the index, so the copy in the table isnt used.

Making the pair the primary key stores it once with the same access path, so the queries dont change and the index goes. `.testmondata` goes from 18.1 MiB to 10.4 MiB.

The primary key forbids duplicate pairs, where the old table allowed them. Nothing ever inserts one though. `get_tests_fingerprints` builds the deps of a test from coverage data keyed by filename, so a file shows up once per test, and every test gets its own `test_execution` id. The other writer, `sync_db_fs_tests`, inserts a single dep.

`DATA_VERSION` goes to 15 so `check_data_version` discards existing files and they get re-recorded. No migration code.
